### PR TITLE
docs(readme): refresh with features, keymaps, and current versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align='center'>
    <p>
-      <a href="https://github.com/kpalatzky/nvim.dotfiles#is=awesome">
+      <a href="https://github.com/kboshold/nvim.dotfiles#is=awesome">
          <picture>
             <source media="(prefers-color-scheme: dark)" type="image/svg+xml" srcset="./docs/assets/logo_dark.svg">
             <img alt="Logo with the Lettering Neovim and a lazy ninja on the left" src="./docs/assets/logo_light.svg">
@@ -8,22 +8,22 @@
       </a>
    </p>
    <p>
-      <a href="https://github.com/kpalatzky/nvim.dotfiles/blob/master/LICENSE">
+      <a href="https://github.com/kboshold/nvim.dotfiles/blob/main/LICENSE">
          <picture>
-            <source media="(prefers-color-scheme: dark)" type="image/svg+xml" srcset="https://img.shields.io/github/license/kpalatzky/nvim.dotfiles.svg?color=cba6f7&labelColor=b4befe">
-            <img src="https://img.shields.io/github/license/kpalatzky/nvim.dotfiles.svg?color=8839ef" alt="MIT License"/>
+            <source media="(prefers-color-scheme: dark)" type="image/svg+xml" srcset="https://img.shields.io/github/license/kboshold/nvim.dotfiles.svg?color=cba6f7&labelColor=b4befe">
+            <img src="https://img.shields.io/github/license/kboshold/nvim.dotfiles.svg?color=8839ef" alt="MIT License"/>
          </picture>
       </a>
       <a href="https://github.com/neovim/neovim#is-also-awesome">
          <picture>
-            <source media="(prefers-color-scheme: dark)" type="image/svg+xml" srcset="https://img.shields.io/badge/%3E%3D0.10.0-a6e3a1?logo=neovim&label=neovim&labelColor=74c7ec&logoColor=313244">
-            <img alt="Neovim 0.10 is required" src="https://img.shields.io/badge/%3E%3D0.10.0-40a02b?logo=neovim&label=neovim&labelColor=1e66f5">
+            <source media="(prefers-color-scheme: dark)" type="image/svg+xml" srcset="https://img.shields.io/badge/%3E%3D0.11.0-a6e3a1?logo=neovim&label=neovim&labelColor=74c7ec&logoColor=313244">
+            <img alt="Neovim 0.11 is required" src="https://img.shields.io/badge/%3E%3D0.11.0-40a02b?logo=neovim&label=neovim&labelColor=1e66f5">
          </picture>
        </a>
-      <a href="https://github.com/neovim/neovim#0.11-is-also-awesome">
+      <a href="https://github.com/neovim/neovim#0.12-is-also-awesome">
          <picture>
-            <source media="(prefers-color-scheme: dark)" type="image/svg+xml" srcset="https://img.shields.io/badge/0.11.0-a6e3a1?logo=neovim&label=neovim&labelColor=74c7ec&logoColor=313244">
-            <img alt="Neovim 0.11 is supported" src="https://img.shields.io/badge/0.11.0-40a02b?logo=neovim&label=neovim&labelColor=1e66f5">
+            <source media="(prefers-color-scheme: dark)" type="image/svg+xml" srcset="https://img.shields.io/badge/0.12.0-a6e3a1?logo=neovim&label=neovim&labelColor=74c7ec&logoColor=313244">
+            <img alt="Neovim 0.12 is supported" src="https://img.shields.io/badge/0.12.0-40a02b?logo=neovim&label=neovim&labelColor=1e66f5">
          </picture>
        </a>
    </p>
@@ -40,7 +40,7 @@
 
 | Tool       | Version   | Usage                                                                                 | Note                                                                                                      |
 | ---------- | --------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| Neovim     | >= 0.10.0 | <img src="https://img.shields.io/badge/required-f491ac?style=flat" alt="Required"/>   | [Installation Guide](https://github.com/neovim/neovim/blob/master/INSTALL.md#is-also-awesome)             |
+| Neovim     | >= 0.11.0 | <img src="https://img.shields.io/badge/required-f491ac?style=flat" alt="Required"/>   | [Installation Guide](https://github.com/neovim/neovim/blob/master/INSTALL.md#is-also-awesome)             |
 | Git        | >= 2.19.0 | <img src="https://img.shields.io/badge/required-f491ac?style=flat" alt="Required"/>   | [Download](https://git-scm.com/downloads#is-also-awesome)                                                 |
 | NerdFont   | -         | <img src="https://img.shields.io/badge/suggested-cba6f7?style=flat" alt="Suggested"/> | [Download](https://www.nerdfonts.com/font-downloads#is-also-awesome) (i.e. `JetBrainsMono Nerd Font`)     |
 | C Compiler | -         | <img src="https://img.shields.io/badge/suggested-cba6f7?style=flat" alt="Suggested"/> | See [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter?tab=readme-ov-file#requirements) |
@@ -76,14 +76,71 @@ nvim --headless -c 'Lazy install' -c 'qa'
 
 Now you can use `nvim` and enjoy the configuration! 🎉
 
-#### 🧙 Using the dotfiles
+## 🍱 What's in the bento?
 
-The [kboshold/dotfiles](https://github.com/kboshold/dotfiles) also include the latest version of this Neovim configuration. So if you want to use them, you do not have to do anything at all! 🤯
+Built on [LazyVim](https://www.lazyvim.org/). Below is the stuff on top.
+
+#### 🎨 Look & feel
+- Catppuccin Mocha with a 9-color indent cycle (custom `Indent*` / `IndentScope*` highlights)
+- Snacks dashboard with custom ASCII branding
+- Lualine with a mode-colored `CursorLineNr` (sampled from the current mode's lualine highlight)
+- Rainbow delimiters, render-markdown, virt-column
+
+#### 🤖 AI
+- Copilot (loads on `InsertEnter`) + CopilotChat
+- [Sidekick](https://github.com/folke/sidekick.nvim) — multi-CLI AI orchestration (Claude, etc.)
+
+#### 🔍 Navigation
+- Snacks picker + explorer (auto-opens on `nvim` with no args or a directory; skipped for piped input)
+- [Oil.nvim](https://github.com/stevearc/oil.nvim) floating browser (`<leader>oo`/`<leader>od`)
+- [vim-tmux-navigator](https://github.com/christoomey/vim-tmux-navigator) (`<C-h/j/k/l>`)
+
+#### 🧠 Language / LSP
+- Vue/TypeScript hybrid mode (volar + vtsls with `@vue/typescript-plugin`)
+- Prisma, Nix (alejandra), Python, Ansible, Docker, Helm, JSON, Markdown, SQL, Tailwind, YAML (via LazyVim extras)
+- lazydev for Lua + Neovim API awareness
+
+#### ✍️ Completion & formatting
+- [blink.cmp](https://github.com/saghen/blink.cmp) with `ai_cmp` integration
+- Conform with a `from_node_modules` resolver — prefers the project's local `eslint_d` / `prisma` / `jsonsort` over globals, falls back cleanly
+
+#### 🔧 Git
+- [smart-commit.nvim](https://github.com/kboshold/smart-commit.nvim) — pre-commit checks + Copilot-generated messages
+- Diffview, mini-diff, Octo (PR/issue review)
+
+#### 🔐 Secrets
+- [cloak.nvim](https://github.com/laytan/cloak.nvim) — auto-masks values in `.env*` files
 
 ### ⌨️ Keymaps
 
-> [!TIP]  
-> You can of course also view the keymaps directly in Neovim with `:nmap`, `:vmap` as usual (Typing `:help map` in Neovim will give you more info.)
+> [!TIP]
+> The full list is discoverable via [which-key](https://github.com/folke/which-key.nvim) (just press `<leader>` and wait) or `:Telescope keymaps`. The table below only lists the custom bindings on top of LazyVim defaults.
 
-> [!IMPORTANT]  
-> The following keymaps are automatically extracted from the code via a pipeline and inserted here. Therefore, make sure that you have the latest version.
+| Mapping | Mode | Description |
+| ------- | ---- | ----------- |
+| `dih` / `cih` / `vih` | n | Delete / change / select the treesitter node under cursor |
+| `gf` | n | Open file under cursor; supports `file.lua:10` and `file.lua:10-20` ranges |
+| `<leader>e` | n | Toggle snacks file explorer (reuses existing pane if open) |
+| `<leader>oo` | n | Open Oil file browser |
+| `<leader>od` | n | Oil floating preview |
+| `<leader>sc` | n | Toggle smart-commit status window |
+| `<leader>gdm` | n | Diff current branch vs `origin/main` |
+| `<leader>gds` | n | Diff uncommitted changes |
+| `<leader>um` | n | Toggle render-markdown |
+| `<leader>aa` / `<leader>as` | n | Sidekick: toggle CLI / select CLI |
+| `<leader>at` / `<leader>av` | n / x | Send current node / visual selection to Sidekick |
+| `<leader>ap` | n / x | Sidekick prompt picker |
+| `<leader>ac` | n | Toggle Sidekick Claude |
+| `<C-.>` | n / x / i / t | Switch focus to Sidekick |
+| `<Tab>` | i | Apply next-edit suggestion (Sidekick); falls back to `<Tab>` |
+| `<C-h/j/k/l>` / `<C-\>` | n | Tmux-aware pane navigation |
+
+### 🧰 Custom commands
+
+| Command | Description |
+| ------- | ----------- |
+| `:PathCopyName` | Copy filename to clipboard |
+| `:PathCopyRelative` | Copy relative path |
+| `:PathCopyRelativeFull` | Relative path + current (or visual) line range |
+| `:PathCopyAbsolute` | Copy absolute path |
+| `:PathCopyAbsoluteFull` | Absolute path + line range |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align='center'>
    <p>
-      <a href="https://github.com/kboshold/nvim.dotfiles#is=awesome">
+      <a href="https://github.com/kboshold/nvim.dotfiles">
          <picture>
             <source media="(prefers-color-scheme: dark)" type="image/svg+xml" srcset="./docs/assets/logo_dark.svg">
             <img alt="Logo with the Lettering Neovim and a lazy ninja on the left" src="./docs/assets/logo_light.svg">
@@ -14,13 +14,13 @@
             <img src="https://img.shields.io/github/license/kboshold/nvim.dotfiles.svg?color=8839ef" alt="MIT License"/>
          </picture>
       </a>
-      <a href="https://github.com/neovim/neovim#is-also-awesome">
+      <a href="https://github.com/neovim/neovim">
          <picture>
             <source media="(prefers-color-scheme: dark)" type="image/svg+xml" srcset="https://img.shields.io/badge/%3E%3D0.11.0-a6e3a1?logo=neovim&label=neovim&labelColor=74c7ec&logoColor=313244">
             <img alt="Neovim 0.11 is required" src="https://img.shields.io/badge/%3E%3D0.11.0-40a02b?logo=neovim&label=neovim&labelColor=1e66f5">
          </picture>
        </a>
-      <a href="https://github.com/neovim/neovim#0.12-is-also-awesome">
+      <a href="https://github.com/neovim/neovim/releases/tag/v0.12.0">
          <picture>
             <source media="(prefers-color-scheme: dark)" type="image/svg+xml" srcset="https://img.shields.io/badge/0.12.0-a6e3a1?logo=neovim&label=neovim&labelColor=74c7ec&logoColor=313244">
             <img alt="Neovim 0.12 is supported" src="https://img.shields.io/badge/0.12.0-40a02b?logo=neovim&label=neovim&labelColor=1e66f5">
@@ -40,9 +40,9 @@
 
 | Tool       | Version   | Usage                                                                                 | Note                                                                                                      |
 | ---------- | --------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| Neovim     | >= 0.11.0 | <img src="https://img.shields.io/badge/required-f491ac?style=flat" alt="Required"/>   | [Installation Guide](https://github.com/neovim/neovim/blob/master/INSTALL.md#is-also-awesome)             |
-| Git        | >= 2.19.0 | <img src="https://img.shields.io/badge/required-f491ac?style=flat" alt="Required"/>   | [Download](https://git-scm.com/downloads#is-also-awesome)                                                 |
-| NerdFont   | -         | <img src="https://img.shields.io/badge/suggested-cba6f7?style=flat" alt="Suggested"/> | [Download](https://www.nerdfonts.com/font-downloads#is-also-awesome) (i.e. `JetBrainsMono Nerd Font`)     |
+| Neovim     | >= 0.11.0 | <img src="https://img.shields.io/badge/required-f491ac?style=flat" alt="Required"/>   | [Installation Guide](https://github.com/neovim/neovim/blob/master/INSTALL.md)             |
+| Git        | >= 2.19.0 | <img src="https://img.shields.io/badge/required-f491ac?style=flat" alt="Required"/>   | [Download](https://git-scm.com/downloads)                                                 |
+| NerdFont   | -         | <img src="https://img.shields.io/badge/suggested-cba6f7?style=flat" alt="Suggested"/> | [Download](https://www.nerdfonts.com/font-downloads) (i.e. `JetBrainsMono Nerd Font`)     |
 | C Compiler | -         | <img src="https://img.shields.io/badge/suggested-cba6f7?style=flat" alt="Suggested"/> | See [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter?tab=readme-ov-file#requirements) |
 | ripgrep    | >= 14.1.0 | <img src="https://img.shields.io/badge/suggested-cba6f7?style=flat" alt="Suggested"/> | [Installation](https://github.com/BurntSushi/ripgrep?tab=readme-ov-file#installation)                     |
 | fd         | >= 10.1.0 | <img src="https://img.shields.io/badge/suggested-cba6f7?style=flat" alt="Suggested"/> | [Installation](https://github.com/sharkdp/fd?tab=readme-ov-file#installation)                             |
@@ -118,21 +118,19 @@ Built on [LazyVim](https://www.lazyvim.org/). Below is the stuff on top.
 
 | Mapping | Mode | Description |
 | ------- | ---- | ----------- |
-| `dih` / `cih` / `vih` | n | Delete / change / select the treesitter node under cursor |
-| `gf` | n | Open file under cursor; supports `file.lua:10` and `file.lua:10-20` ranges |
-| `<leader>e` | n | Toggle snacks file explorer (reuses existing pane if open) |
-| `<leader>oo` | n | Open Oil file browser |
-| `<leader>od` | n | Oil floating preview |
+| `dih` / `cih` / `vih` | n | Delete / change / select the TS node at cursor |
+| `gf` | n | Open file under cursor; supports `:line` and `:line-line` suffix |
+| `<leader>e` | n | Toggle snacks explorer (reuses open pane) |
+| `<leader>oo` / `<leader>od` | n | Oil browser / floating preview |
 | `<leader>sc` | n | Toggle smart-commit status window |
-| `<leader>gdm` | n | Diff current branch vs `origin/main` |
-| `<leader>gds` | n | Diff uncommitted changes |
+| `<leader>gdm` / `<leader>gds` | n | Diffview: branch vs `origin/main` / uncommitted |
 | `<leader>um` | n | Toggle render-markdown |
-| `<leader>aa` / `<leader>as` | n | Sidekick: toggle CLI / select CLI |
-| `<leader>at` / `<leader>av` | n / x | Send current node / visual selection to Sidekick |
+| `<leader>aa` / `as` | n | Sidekick: toggle CLI / select CLI |
+| `<leader>at` / `av` | n / x | Send current node / selection to Sidekick |
 | `<leader>ap` | n / x | Sidekick prompt picker |
 | `<leader>ac` | n | Toggle Sidekick Claude |
-| `<C-.>` | n / x / i / t | Switch focus to Sidekick |
-| `<Tab>` | i | Apply next-edit suggestion (Sidekick); falls back to `<Tab>` |
+| `<C-.>` | any | Switch focus to Sidekick |
+| `<Tab>` | i | Apply next-edit suggestion; falls back to `<Tab>` |
 | `<C-h/j/k/l>` / `<C-\>` | n | Tmux-aware pane navigation |
 
 ### 🧰 Custom commands


### PR DESCRIPTION
## Summary

Refreshes the README after the recent config audit. Same playful tone — updated content.

- Fix stale fork-artifact URLs (`kpalatzky/nvim.dotfiles` → `kboshold/nvim.dotfiles`) in the logo link and license badge, plus `master` → `main`
- Bump Neovim version badges (`>= 0.11` required, `0.12` supported) — LazyVim's actual requirement and what the config currently runs on
- Bump the requirements table Neovim row to `>= 0.11.0`
- Drop the "Using the dotfiles" section (pointed at pre-Nix legacy `kboshold/dotfiles`; current setup lives in `kboshold/nix.dotfiles`)
- Add **What's in the bento?** — grouped features list (Look & feel, AI, Navigation, LSP, Completion & formatting, Git, Secrets)
- Replace the empty "auto-extracted" Keymaps teaser with a hand-authored table of the ~16 custom bindings (Sidekick, Oil, smart-commit, tmux-navigator, treesitter node text objects, custom `gf`, etc.)
- Add a **Custom commands** subsection for the `:PathCopy*` family

## Test plan

- [ ] Preview README rendering on GitHub once this PR lands
- [ ] Badges load (license, neovim version)
- [ ] Logo link resolves
- [ ] Table rows don't wrap awkwardly on narrow viewports
- [ ] All keymap table entries match actual bindings (spot-check done locally against source)