### PR TITLE
chore(nvim): stability hardening + 2 new extras (round 3)

### DIFF
--- a/lazyvim.json
+++ b/lazyvim.json
@@ -11,6 +11,7 @@
 		"lazyvim.plugins.extras.editor.mini-diff",
 		"lazyvim.plugins.extras.editor.snacks_explorer",
 		"lazyvim.plugins.extras.editor.snacks_picker",
+		"lazyvim.plugins.extras.formatting.prettier",
 		"lazyvim.plugins.extras.lang.ansible",
 		"lazyvim.plugins.extras.lang.docker",
 		"lazyvim.plugins.extras.lang.helm",
@@ -22,6 +23,7 @@
 		"lazyvim.plugins.extras.lang.typescript",
 		"lazyvim.plugins.extras.lang.sql",
 		"lazyvim.plugins.extras.lang.yaml",
+		"lazyvim.plugins.extras.ui.treesitter-context",
 		"lazyvim.plugins.extras.util.dot",
 		"lazyvim.plugins.extras.util.octo",
 		"lazyvim.plugins.extras.util.mini-hipatterns"

--- a/lua/kboshold/config/autocmds.lua
+++ b/lua/kboshold/config/autocmds.lua
@@ -1,5 +1,8 @@
+local group = vim.api.nvim_create_augroup("kboshold", { clear = true })
+
 -- Set ux_piped_input to `1` for input streams
 vim.api.nvim_create_autocmd("StdinReadPost", {
+  group = group,
   callback = function()
     vim.g.ux_piped_input = 1
   end,
@@ -36,9 +39,11 @@ local function update_cursor_line_nr()
 end
 
 vim.api.nvim_create_autocmd("ModeChanged", {
+  group = group,
   callback = update_cursor_line_nr,
 })
 vim.api.nvim_create_autocmd("BufEnter", {
+  group = group,
   callback = function()
     last_mode_suffix = nil
     update_cursor_line_nr()
@@ -46,6 +51,7 @@ vim.api.nvim_create_autocmd("BufEnter", {
 })
 
 vim.api.nvim_create_autocmd("FileType", {
+  group = group,
   pattern = "markdown",
   callback = function()
     vim.opt_local.conceallevel = 0

--- a/lua/kboshold/config/keymaps.lua
+++ b/lua/kboshold/config/keymaps.lua
@@ -42,8 +42,8 @@ vim.keymap.set("n", "gf", function()
   local start_index = 1
   local found_start = nil
   local found_end = nil
-  while true do
-    found_start, found_end = string.find(line_content, file, start_index)
+  for _ = 1, 20 do
+    found_start, found_end = string.find(line_content, file, start_index, true)
     if not found_start then
       break
     end

--- a/lua/kboshold/config/util.lua
+++ b/lua/kboshold/config/util.lua
@@ -7,6 +7,9 @@ local function rgb_to_hex(r, g, b)
 end
 
 local function hex_to_rgb(hex)
+  if type(hex) ~= "string" or not hex:match("^#%x%x%x%x%x%x$") then
+    return 0, 0, 0
+  end
   local r = tonumber(hex:sub(2, 3), 16)
   local g = tonumber(hex:sub(4, 5), 16)
   local b = tonumber(hex:sub(6, 7), 16)

--- a/lua/kboshold/plugins/ai/copilot-chat.lua
+++ b/lua/kboshold/plugins/ai/copilot-chat.lua
@@ -1,18 +1,11 @@
 return {
   "CopilotC-Nvim/CopilotChat.nvim",
   cmd = { "CopilotChat", "CopilotChatToggle", "CopilotChatOpen" },
-  opts = {
-    model = "gpt-4.1",
-    show_help = false,
-    window = {
-      layout = "vertical",
-      width = 0.3,
-    },
-  },
-  config = function(_, opts)
-    local chat = require("CopilotChat")
-
+  main = "CopilotChat",
+  init = function()
+    local group = vim.api.nvim_create_augroup("kboshold_copilot_chat", { clear = true })
     vim.api.nvim_create_autocmd("FileType", {
+      group = group,
       pattern = "copilot-chat",
       callback = function()
         vim.opt_local.relativenumber = true
@@ -22,7 +15,13 @@ return {
         vim.opt_local.numberwidth = 3
       end,
     })
-
-    chat.setup(opts)
   end,
+  opts = {
+    model = "gpt-4.1",
+    show_help = false,
+    window = {
+      layout = "vertical",
+      width = 0.3,
+    },
+  },
 }

--- a/lua/kboshold/plugins/lsp/vue.lua
+++ b/lua/kboshold/plugins/lsp/vue.lua
@@ -1,14 +1,4 @@
 return {
-  recommended = function()
-    return LazyVim.extras.wants({
-      ft = "vue",
-      root = { "vue.config.js" },
-    })
-  end,
-
-  -- depends on the typescript extra
-  { import = "lazyvim.plugins.extras.lang.typescript" },
-
   {
     "nvim-treesitter/nvim-treesitter",
     opts = { ensure_installed = { "vue", "css" } },
@@ -37,8 +27,14 @@ return {
               end
               local ts_client = clients[1]
 
-              local param = unpack(result)
+              local param = unpack(result or {})
+              if not param then
+                return
+              end
               local id, command, payload = unpack(param)
+              if not id then
+                return
+              end
               ts_client:exec_cmd({
                 command = "typescript.tsserverRequest",
                 arguments = {
@@ -62,6 +58,8 @@ return {
   {
     "neovim/nvim-lspconfig",
     opts = function(_, opts)
+      opts.servers.vtsls.filetypes = opts.servers.vtsls.filetypes
+        or { "typescript", "javascript", "javascriptreact", "typescriptreact" }
       table.insert(opts.servers.vtsls.filetypes, "vue")
       LazyVim.extend(opts.servers.vtsls, "settings.vtsls.tsserver.globalPlugins", {
         {

--- a/lua/kboshold/plugins/ui/lualine.lua
+++ b/lua/kboshold/plugins/ui/lualine.lua
@@ -134,12 +134,11 @@ return {
             function()
               local bufnr = vim.api.nvim_get_current_buf()
               local clients = vim.lsp.get_clients({ bufnr = bufnr })
-              if clients == nil then
+              if #clients == 0 then
                 return ""
               end
 
               local icons = {
-                [0] = "",
                 [1] = "󰇊",
                 [2] = "󰇋",
                 [3] = "󰇌",
@@ -147,7 +146,7 @@ return {
                 [5] = "󰇎",
                 [6] = "󰇏",
               }
-              return icons[#clients] or ""
+              return icons[math.min(#clients, 6)] or ""
             end,
             color = { fg = mocha.blue },
             padding = { left = 0, right = 1 },


### PR DESCRIPTION
## Summary

Third audit round focused on **stability, feature gaps, and idiomatic LazyVim patterns** — not startup time. No regressions expected; behavior for happy-path flows is unchanged.

### Stability fixes
- **Vue LSP** (`plugins/lsp/vue.lua`) — nil-guard \`unpack()\` on tsserver request handler (prevents crash on malformed result); defensive init of \`opts.servers.vtsls.filetypes\` before insert; drop redundant \`{ import = lazyvim.plugins.extras.lang.typescript }\` (already declared in \`lazyvim.json\`).
- **autocmds** (\`config/autocmds.lua\`) — wrap all 4 autocmds in a single augroup (\`kboshold\`) with \`clear = true\` so \`:source\` no longer stacks duplicates.
- **lualine** (\`plugins/ui/lualine.lua\`) — drop dead \`clients == nil\` check; clamp LSP count icon to \`math.min(#clients, 6)\` so 7+ clients don't produce empty output.
- **gf keymap** (\`config/keymaps.lua\`) — cap the filename-search loop at 20 iterations; switch to plain \`string.find(..., true)\` so filenames with regex metacharacters match literally.
- **util.color.hex_to_rgb** (\`config/util.lua\`) — validate \`#rrggbb\` input; return \`0,0,0\` on malformed hex so downstream \`darken\`/\`lighten\` don't crash on nil arithmetic.

### Idiomatic refactor
- **CopilotChat** (\`plugins/ai/copilot-chat.lua\`) — drop the \`config = function()\` wrapper. Set \`main = "CopilotChat"\` so lazy auto-invokes \`setup(opts)\`; move the FileType autocmd into \`init\` with its own augroup.

### New LazyVim extras
- \`ui.treesitter-context\` — sticky code context header (especially valuable for long Vue SFC script blocks).
- \`formatting.prettier\` — appends \`prettier\` after \`eslint_d\` for js/ts/vue, adds css/html/markdown/yaml/json formatting. Guarded: only runs when a prettier config file is found.

### Plugins that are _already_ loaded (no action taken)
Audit confirmed these are shipped by LazyVim core (\`lazy/LazyVim/lua/lazyvim/plugins/editor.lua\`):
- \`flash.nvim\`, \`trouble.nvim\`, \`todo-comments.nvim\`

## Test plan

- [x] \`stylua --check lua/\` — clean
- [x] \`nvim --headless loadfile\` on each edited file — all pass
- [x] Isolated \`NVIM_APPNAME=nvim-dev\` boot — no errors in \`:messages\`
- [x] All 4 target plugins registered in lazy spec (flash, trouble, todo-comments, nvim-treesitter-context)
- [x] Open a real \`.lua\` file — no errors
- [ ] Follow-up in daily use: verify prettier runs on \`.css\` / \`.md\` / \`.vue\` saves when a prettier config is present
- [ ] Follow-up: verify treesitter-context header renders inside long functions / Vue SFCs